### PR TITLE
Use alias instead of module name for blacklisting

### DIFF
--- a/rtw88_blacklist.conf
+++ b/rtw88_blacklist.conf
@@ -1,5 +1,2 @@
-blacklist rtw88
-blacklist rtwpci
-blacklist rtw88_8822ce
-blacklist rtw88_pci
-blacklist rtw88_8822c
+alias pci:v000010ECd0000C82Fsv*sd*bc*sc*i* rtl88x2ce
+alias pci:v000010ECd0000C822sv*sd*bc*sc*i* rtl88x2ce


### PR DESCRIPTION
Use alias instead of module name for blacklisting